### PR TITLE
[BIO-20]: Add password protection to production site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@ npm run preview  # Preview production build locally
 npm run astro    # Access Astro CLI commands
 ```
 
-**Live Site:** https://biorunway.com
+**Live Site:** https://biorunway.com (Password Protected)
+**Password:** biorunwayiscool
 
 ## Architecture Overview
 
@@ -23,7 +24,7 @@ npm run astro    # Access Astro CLI commands
 - **Content**: Content Collections with Zod schema validation
 - **Backend**: Supabase for email list management
 - **Animation**: Framer Motion v12.16.0
-- **Deployment**: GitHub Pages (`/biorunway-website` base path)
+- **Deployment**: Netlify with custom domain and password protection
 
 ### Key Architecture Patterns
 
@@ -140,7 +141,13 @@ The project is undergoing a major homepage redesign with consolidated informatio
 ```bash
 PUBLIC_SUPABASE_URL=your_supabase_url
 PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+SITE_PASSWORD=biorunwayiscool  # For production password protection
 ```
+
+### Site Access
+- **Production Site**: https://biorunway.com - Password protected with "biorunwayiscool"
+- **Preview Deployments**: Branch and deploy previews remain unprotected for development
+- **Password Protection**: Applied only to production domain via Netlify configuration
 
 ### Supabase Integration
 - Email collection managed through `src/lib/supabase.js`

--- a/netlify.toml
+++ b/netlify.toml
@@ -34,6 +34,7 @@
 [context.branch-deploy]
   environment = { PUBLIC_STAGING_PASSWORD = "your-staging-password" }
 
-# Main production context (no password protection)
+# Main production context with password protection
 [context.production]
+  password = "$SITE_PASSWORD"
   environment = { PUBLIC_STAGING_PASSWORD = "" }


### PR DESCRIPTION
## Summary
- Implements site-wide password protection for production domain (biorunway.com)
- Uses existing Netlify environment variable SITE_PASSWORD with value "biorunwayiscool"
- Keeps preview deployments unprotected for development workflow

## Changes Made
- **netlify.toml**: Added `password = "$SITE_PASSWORD"` to production context
- **CLAUDE.md**: Updated documentation with access instructions and environment variable

## Technical Details
- Password protection applies only to production context (biorunway.com domain)
- Branch and deploy preview deployments remain accessible without password
- Uses Netlify's built-in password protection feature
- Environment variable SITE_PASSWORD already configured on Netlify with correct value

## Test Plan
- [ ] Verify production site requires password after deployment
- [ ] Confirm preview deployments remain unprotected
- [ ] Test that email signup functionality works behind password protection
- [ ] Validate SSL and domain functionality remain intact

🤖 Generated with [Claude Code](https://claude.ai/code)